### PR TITLE
Add timed queue option

### DIFF
--- a/crow.go
+++ b/crow.go
@@ -4,7 +4,8 @@ package murder
 // Interface for any storage system for the orchestrator to use
 type Crow interface {
 	QueueSize(string) int                   // Query main queue size
-	AddToQueue(string, interface{})         // Add object to queue
+	QueueTimeSinceCreation(string) int	// Query time since queue creation
+	AddToQueue(*Murder, interface{})        // Add object to queue
 	GetQueueContents(string) []string       // Retrieve all contents of queue
 	ClearQueue(string, string) error        // Clear all queue contents
 	CreateLockKey(string, string, int) bool // Create lock key for a queue, confirm if lock acquired, and set TTL

--- a/crow.go
+++ b/crow.go
@@ -5,7 +5,7 @@ package murder
 type Crow interface {
 	QueueSize(string) int                   // Query main queue size
 	QueueTimeSinceCreation(string) int	// Query time since queue creation
-	AddToQueue(*Murder, interface{})        // Add object to queue
+	AddToQueue(string, interface{}, bool)   // Add object to queue
 	GetQueueContents(string) []string       // Retrieve all contents of queue
 	ClearQueue(string, string) error        // Clear all queue contents
 	CreateLockKey(string, string, int) bool // Create lock key for a queue, confirm if lock acquired, and set TTL

--- a/murder.go
+++ b/murder.go
@@ -24,7 +24,7 @@ func (m *Murder) Add(obj interface{}) {
 		queueName := newUUID()
 		m.crow.MoveToReady(m.workerGroupID, queueName)
 	}
-	m.crow.AddToQueue(m,  obj)
+	m.crow.AddToQueue(m.workerGroupID,  obj, ageConfigured)
 }
 
 // Lock :

--- a/redis-crow.go
+++ b/redis-crow.go
@@ -31,9 +31,7 @@ func (c *RedisCrow) CurrentQueue(groupName string) string {
 	return fmt.Sprintf("murder::%s::mainQueue", groupName)
 }
 
-func (c *RedisCrow) AddToQueue(murder *Murder, obj interface{}) {
-	groupName := murder.workerGroupID
-	ageConfigured := murder.AgeConfigured()
+func (c *RedisCrow) AddToQueue(groupName string, obj interface{}, ageConfigured bool) {
 	marshalled, _ := json.Marshal(obj)
 	currentQueue := c.CurrentQueue(groupName)
 	if !c.Redis.Exists(currentQueue).Val() && ageConfigured {

--- a/redis-crow.go
+++ b/redis-crow.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"time"
-
+	"strconv"
 	"gopkg.in/redis.v5"
 )
 
@@ -18,12 +18,28 @@ func (c *RedisCrow) QueueSize(groupName string) int {
 	return int(size)
 }
 
+func (c *RedisCrow) QueueTimeSinceCreation(groupName string) int {
+	queueAgeKey := fmt.Sprintf("murder::%s::age", c.CurrentQueue(groupName))
+	timeSinceCreation, _ := c.Redis.Get(queueAgeKey).Result()
+	timeSinceCreationInt, _ := strconv.ParseInt(timeSinceCreation, 10, 64)
+	age := time.Now().Unix() - timeSinceCreationInt
+	return int(age)
+}
+
+
 func (c *RedisCrow) CurrentQueue(groupName string) string {
 	return fmt.Sprintf("murder::%s::mainQueue", groupName)
 }
 
-func (c *RedisCrow) AddToQueue(groupName string, obj interface{}) {
+func (c *RedisCrow) AddToQueue(murder *Murder, obj interface{}) {
+	groupName := murder.workerGroupID
+	ageConfigured := murder.AgeConfigured()
 	marshalled, _ := json.Marshal(obj)
+	currentQueue := c.CurrentQueue(groupName)
+	if !c.Redis.Exists(currentQueue).Val() && ageConfigured {
+		queueAgeKey := fmt.Sprintf("murder::%s::age", currentQueue)
+		c.Redis.Set(queueAgeKey, time.Now().Unix(), time.Duration(0))
+	}
 	c.Redis.LPush(c.CurrentQueue(groupName), marshalled).Result()
 }
 
@@ -81,6 +97,7 @@ func (c *RedisCrow) RemoveLockKey(lockKey string) {
 func (c *RedisCrow) MoveToReady(groupName, newName string) {
 	ok, _ := c.Redis.SetNX(fmt.Sprintf("%s::lock", c.CurrentQueue(groupName)), "1", time.Duration(1)*time.Second).Result()
 	if ok {
+		c.Redis.Del(fmt.Sprintf("murder::%s::age", c.CurrentQueue(groupName)))
 		c.Redis.Rename(c.CurrentQueue(groupName), fmt.Sprintf("murder::crows::%s", newName))
 		c.Redis.SAdd(fmt.Sprintf("murder::%s::ready", groupName), newName)
 		c.Redis.Del(fmt.Sprintf("%s::lock", c.CurrentQueue(groupName)))


### PR DESCRIPTION
Adds the option of moving the queue to ready after a certain time period
## PR contents:
- Add a new attribute to Murder struct `queueAge` in seconds
- Add a new constructor for Murder with `queueAge` specified
- Modify the `Add` method in Murder to move queue to ready if the queue has existed for longer than the `queueAge`